### PR TITLE
Resetting setInterval after restart

### DIFF
--- a/CircleTimer.js
+++ b/CircleTimer.js
@@ -80,6 +80,9 @@ export default class CircleTimer extends React.Component {
   }
 
   restart = () => {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
     this.setState(
       {
         elapsedTime: this.props.seconds,


### PR DESCRIPTION
Without removing setInterval after each restart, timer 'fills' faster on each iteration